### PR TITLE
Improve error checking

### DIFF
--- a/codespell.py
+++ b/codespell.py
@@ -159,6 +159,16 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                         if spell_checker.check(wrd):
                             valid = True
                             break
+                        else:
+                            # Try splitting camel case words and checking each sub-word
+                            if output_lvl > 1:
+                                print("Trying splitting camel case word: {wrd}")
+                            sub_words = splitCamelCase(wrd)
+                            if len(sub_words) > 1 and checkWords(
+                                spell_checker, sub_words
+                            ):
+                                valid = True
+                                break
                     except BaseException:
                         print(f"Caught an exception for word {error_word} {wrd}")
 

--- a/codespell.py
+++ b/codespell.py
@@ -122,39 +122,41 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
             if output_lvl > 1:
                 print(f"Error: {error.word}")
 
+            error_word = error.word
+
             # Check if the bad word starts with a prefix.
             # If so, spell check the word without that prefix.
             #
             for pre in prefixes:
-                if error.word.startswith(pre):
+                if error_word.startswith(pre):
                     # check if the word is only the prefix
-                    if len(pre) == len(error.word):
+                    if len(pre) == len(error_word):
                         if output_lvl > 1:
                             print(f"Prefix '{pre}' matches word")
                         break
 
                     # remove the prefix
-                    wrd = error.word[len(pre) :]
+                    wrd = error_word[len(pre) :]
                     if output_lvl > 1:
-                        print(f"Trying without '{pre}' prefix: {error.word} -> {wrd}")
+                        print(f"Trying without '{pre}' prefix: {error_word} -> {wrd}")
                     try:
                         if spell_checker.check(wrd):
                             break
                     except BaseException:
-                        print(f"Caught an exception for word {error.word} {wrd}")
+                        print(f"Caught an exception for word {error_word} {wrd}")
 
             # Try splitting camel case words and checking each sub-word
 
             if output_lvl > 1:
-                print(f"Trying splitting camel case word: {error.word}")
-            sub_words = splitCamelCase(error.word)
+                print(f"Trying splitting camel case word: {error_word}")
+            sub_words = splitCamelCase(error_word)
             if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
                 continue
 
             # Check for possessive words
 
-            if error.word.endswith("'s"):
-                wrd = error.word[:-2]
+            if error_word.endswith("'s"):
+                wrd = error_word[:-2]
                 if spell_checker.check(wrd):
                     continue
 

--- a/codespell.py
+++ b/codespell.py
@@ -81,6 +81,14 @@ def load_text_file(filename):
     return output
 
 
+def checkWords(spell_checker, words):
+    """Check each word and report False if at least one has error."""
+    for word in words:
+        if not spell_checker.check(word):
+            return False
+    return True
+
+
 def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefixes=[]):
     """Check spelling in ``filename``."""
 
@@ -140,13 +148,8 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
             if output_lvl > 1:
                 print(f"Trying splitting camel case word: {error.word}")
             sub_words = splitCamelCase(error.word)
-            if len(sub_words) > 1:
-                ok_flag = True
-                for s in sub_words:
-                    if not spell_checker.check(s):
-                        ok_flag = False
-                if ok_flag:
-                    continue
+            if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
+                continue
 
             # Check for possessive words
 

--- a/codespell.py
+++ b/codespell.py
@@ -123,7 +123,7 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                     if len(pre) == len(error.word):
                         if output_lvl > 1:
                             print(f"Prefix '{pre}' matches word")
-                        continue
+                        break
 
                     # remove the prefix
                     wrd = error.word[len(pre) :]
@@ -131,7 +131,7 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                         print(f"Trying without '{pre}' prefix: {error.word} -> {wrd}")
                     try:
                         if spell_checker.check(wrd):
-                            continue
+                            break
                     except BaseException:
                         print(f"Caught an exception for word {error.word} {wrd}")
 

--- a/codespell.py
+++ b/codespell.py
@@ -98,8 +98,7 @@ def spell_check_comment(
     """Check comment and return list of identified issues if any."""
 
     if output_lvl > 1:
-        print(f"Comment: {c}")
-        print(type(c))
+        print(f"Line {c.line_number()}: {c}")
 
     mistakes = []
     spell_checker.set_text(c.text())

--- a/codespell.py
+++ b/codespell.py
@@ -58,15 +58,16 @@ def splitCamelCase(word):
 
 
 def getMimeType(filepath):
-    """Map `filepath`` extension to file type."""
+    """Map ``filepath`` extension to file type."""
     name, ext = os.path.splitext(filepath)
     return SUFFIX2MIME.get(ext, "text/plain")
 
 
 def load_text_file(filename):
-    """
+    """Parse plain text file as list of ``comment_parser.common.Comment``.
+
     For a regular text file, we don't need to parse it for comments. We
-    just pass every line to the spell checked.
+    just pass every line to the spellchecker.
     """
 
     output = []

--- a/codespell.py
+++ b/codespell.py
@@ -121,6 +121,8 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                 if error.word.startswith(pre):
                     # check if the word is only the prefix
                     if len(pre) == len(error.word):
+                        if output_lvl > 1:
+                            print(f"Prefix '{pre}' matches word")
                         continue
 
                     # remove the prefix

--- a/codespell.py
+++ b/codespell.py
@@ -148,6 +148,7 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                     if len(pre) == len(error_word):
                         if output_lvl > 1:
                             print(f"Prefix '{pre}' matches word")
+                        valid = True
                         break
 
                     # remove the prefix
@@ -156,9 +157,13 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                         print(f"Trying without '{pre}' prefix: {error_word} -> {wrd}")
                     try:
                         if spell_checker.check(wrd):
+                            valid = True
                             break
                     except BaseException:
                         print(f"Caught an exception for word {error_word} {wrd}")
+
+            if valid:
+                continue
 
             # Try splitting camel case words and checking each sub-word
 

--- a/codespell.py
+++ b/codespell.py
@@ -89,6 +89,93 @@ def checkWords(spell_checker, words):
     return True
 
 
+def spell_check_comment(
+    spell_checker: SpellChecker,
+    c: comment_parser.common.Comment,
+    prefixes: list[str] = [],
+    output_lvl=2,
+) -> list[str]:
+    """Check comment and return list of identified issues if any."""
+
+    if output_lvl > 1:
+        print(f"Comment: {c}")
+        print(type(c))
+
+    mistakes = []
+    spell_checker.set_text(c.text())
+
+    for error in spell_checker:
+        if output_lvl > 1:
+            print(f"Error: {error.word}")
+
+        error_word = error.word
+
+        valid = False
+
+        # Check for contractions
+        for contraction in ["'d", "'s", "'th"]:
+            if error_word.endswith(contraction):
+                error_word = error_word[: -len(contraction)]
+                if output_lvl > 1:
+                    print(f"Stripping contraction: {error.word} -> {error_word}")
+                if spell_checker.check(error_word):
+                    valid = True
+                break
+
+        if valid:
+            continue
+
+        # Check if the bad word starts with a prefix.
+        # If so, spell check the word without that prefix.
+        #
+        for pre in prefixes:
+            if error_word.startswith(pre):
+                # check if the word is only the prefix
+                if len(pre) == len(error_word):
+                    if output_lvl > 1:
+                        print(f"Prefix '{pre}' matches word")
+                    valid = True
+                    break
+
+                # remove the prefix
+                wrd = error_word[len(pre) :]
+                if output_lvl > 1:
+                    print(f"Trying without '{pre}' prefix: {error_word} -> {wrd}")
+                try:
+                    if spell_checker.check(wrd):
+                        valid = True
+                        break
+                    else:
+                        # Try splitting camel case words and checking each sub-word
+                        if output_lvl > 1:
+                            print("Trying splitting camel case word: {wrd}")
+                        sub_words = splitCamelCase(wrd)
+                        if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
+                            valid = True
+                            break
+                except BaseException:
+                    print(f"Caught an exception for word {error_word} {wrd}")
+
+        if valid:
+            continue
+
+        # Try splitting camel case words and checking each sub-word
+
+        if output_lvl > 1:
+            print(f"Trying splitting camel case word: {error_word}")
+        sub_words = splitCamelCase(error_word)
+        if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
+            continue
+
+        if output_lvl > 1:
+            msg = f"error: '{error.word}', suggestions: {spell_checker.suggest()}"
+        else:
+            msg = error.word
+        mistakes.append(msg)
+
+    return mistakes
+
+
 def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefixes=[]):
     """Check spelling in ``filename``."""
 
@@ -111,83 +198,9 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
     bad_words = []
 
     for c in clist:
-        if output_lvl > 1:
-            print(f"Comment: {c}")
-            print(type(c))
-
-        mistakes = []
-        spell_checker.set_text(c.text())
-
-        for error in spell_checker:
-            if output_lvl > 1:
-                print(f"Error: {error.word}")
-
-            error_word = error.word
-
-            valid = False
-
-            # Check for contractions
-            for contraction in ["'d", "'s", "'th"]:
-                if error_word.endswith(contraction):
-                    error_word = error_word[: -len(contraction)]
-                    if output_lvl > 1:
-                        print(f"Stripping contraction: {error.word} -> {error_word}")
-                    if spell_checker.check(error_word):
-                        valid = True
-                    break
-
-            if valid:
-                continue
-
-            # Check if the bad word starts with a prefix.
-            # If so, spell check the word without that prefix.
-            #
-            for pre in prefixes:
-                if error_word.startswith(pre):
-                    # check if the word is only the prefix
-                    if len(pre) == len(error_word):
-                        if output_lvl > 1:
-                            print(f"Prefix '{pre}' matches word")
-                        valid = True
-                        break
-
-                    # remove the prefix
-                    wrd = error_word[len(pre) :]
-                    if output_lvl > 1:
-                        print(f"Trying without '{pre}' prefix: {error_word} -> {wrd}")
-                    try:
-                        if spell_checker.check(wrd):
-                            valid = True
-                            break
-                        else:
-                            # Try splitting camel case words and checking each sub-word
-                            if output_lvl > 1:
-                                print("Trying splitting camel case word: {wrd}")
-                            sub_words = splitCamelCase(wrd)
-                            if len(sub_words) > 1 and checkWords(
-                                spell_checker, sub_words
-                            ):
-                                valid = True
-                                break
-                    except BaseException:
-                        print(f"Caught an exception for word {error_word} {wrd}")
-
-            if valid:
-                continue
-
-            # Try splitting camel case words and checking each sub-word
-
-            if output_lvl > 1:
-                print(f"Trying splitting camel case word: {error_word}")
-            sub_words = splitCamelCase(error_word)
-            if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
-                continue
-
-            if output_lvl > 1:
-                msg = f"error: '{error.word}', suggestions: {spell_checker.suggest()}"
-            else:
-                msg = error.word
-            mistakes.append(msg)
+        mistakes = spell_check_comment(
+            spell_checker, c, prefixes=prefixes, output_lvl=output_lvl
+        )
 
         if len(mistakes):
             if output_lvl > 0:

--- a/codespell.py
+++ b/codespell.py
@@ -402,7 +402,7 @@ def main():
 
     suffixes = [*set(args.suffix)]  # remove duplicates
 
-    if output_lvl > 1:
+    if any([args.brief, output_lvl >= 0]):
         print(f"Prefixes: {prefixes}")
         print(f"Suffixes: {suffixes}")
 

--- a/codespell.py
+++ b/codespell.py
@@ -257,7 +257,8 @@ def parse_args():
         "-I",
         action="append",
         dest="dict",
-        help="File that contains words that will be ignored (multiples allowed)."
+        help="File that contains words that will be ignored."
+        " Argument can be passed multiple times."
         " File must contain 1 word per line.",
     )
 
@@ -266,17 +267,19 @@ def parse_args():
         "-e",
         action="append",
         dest="exclude",
-        help="Specify regex for excluding files (multiples allowed)",
+        help="Specify regex for excluding files."
+        " Argument can be passed multiple times.",
     )
 
     parser.add_argument(
         "--skip",
         "-S",
         action="append",
-        help="comma-separated list of files to skip. It "
+        help="Comma-separated list of files to skip. It "
         "accepts globs as well. E.g.: if you want "
         "codespell to skip .eps and .txt files, "
-        'you\'d give "*.eps,*.txt" to this option.',
+        'you\'d give "*.eps,*.txt" to this option.'
+        " Argument can be passed multiple times.",
     )
 
     parser.add_argument(
@@ -285,7 +288,7 @@ def parse_args():
         action="append",
         default=[],
         dest="prefixes",
-        help="Add word prefix (multiples allowed)",
+        help="Add word prefix. Argument can be passed multiple times.",
     )
 
     parser.add_argument(
@@ -303,7 +306,7 @@ def parse_args():
         action="append",
         default=[".h"],
         dest="suffix",
-        help="File name suffix",
+        help="File name suffix. Argument can be passed multiple times.",
     )
 
     parser.add_argument(

--- a/codespell.py
+++ b/codespell.py
@@ -400,10 +400,7 @@ def main():
 
     bad_words = []
 
-    if not args.suffix:
-        suffixes = list(SUFFIX2MIME.keys())
-    else:
-        suffixes = args.suffix
+    suffixes = [*set(args.suffix)]  # remove duplicates
 
     if output_lvl > 1:
         print(f"Prefixes: {prefixes}")

--- a/codespell.py
+++ b/codespell.py
@@ -349,9 +349,12 @@ def parse_args():
     return args
 
 
-def add_dict(enchant_dict, filename):
+def add_dict(enchant_dict, filename, verbose=False):
     """Update ``enchant_dict`` spell checking dictionary with the words listed
     in ``filename`` (one word per line)."""
+    if verbose:
+        print(f"Additional dictionary: {filename}")
+
     with open(filename) as f:
         lines = f.read().splitlines()
 
@@ -366,20 +369,6 @@ def main():
 
     sitk_dict = Dict("en_US")
 
-    # Load the dictionary files
-    #
-    initial_dct = Path(__file__).parent / "additional_dictionary.txt"
-    if not initial_dct.exists():
-        initial_dct = None
-    else:
-        add_dict(sitk_dict, str(initial_dct))
-
-    if args.dict is not None:
-        for d in args.dict:
-            add_dict(sitk_dict, d)
-
-    spell_checker = SpellChecker(sitk_dict, filters=[EmailFilter, URLFilter])
-
     # Set the amount of debugging messages to print.
     output_lvl = 1
     if args.brief:
@@ -389,6 +378,20 @@ def main():
             output_lvl = 2
     if args.miss:
         output_lvl = -1
+
+    # Load the dictionary files
+    #
+    initial_dct = Path(__file__).parent / "additional_dictionary.txt"
+    if not initial_dct.exists():
+        initial_dct = None
+    else:
+        add_dict(sitk_dict, str(initial_dct), any([args.brief, output_lvl >= 0]))
+
+    if args.dict is not None:
+        for d in args.dict:
+            add_dict(sitk_dict, d, any([args.brief, output_lvl >= 0]))
+
+    spell_checker = SpellChecker(sitk_dict, filters=[EmailFilter, URLFilter])
 
     file_list = []
     if len(args.filenames):

--- a/codespell.py
+++ b/codespell.py
@@ -88,7 +88,7 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
         mime_type = getMimeType(filename)
 
     if output_lvl > 0:
-        print("spell_check_file:", filename, ",", mime_type)
+        print(f"spell_check_file: {filename}, {mime_type}")
 
     # Returns a list of comment_parser.parsers.common.Comments
     if mime_type == "text/plain":
@@ -97,14 +97,14 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
         try:
             clist = comment_parser.extract_comments(filename, mime=mime_type)
         except BaseException:
-            print("Parser failed, skipping file", filename)
+            print(f"Parser failed, skipping file {filename}")
             return []
 
     bad_words = []
 
     for c in clist:
         if output_lvl > 1:
-            print("Comment: ", c)
+            print(f"Comment: {c}")
             print(type(c))
 
         mistakes = []
@@ -112,7 +112,7 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
 
         for error in spell_checker:
             if output_lvl > 1:
-                print("Error:", error.word)
+                print(f"Error: {error.word}")
 
             # Check if the bad word starts with a prefix.
             # If so, spell check the word without that prefix.
@@ -126,17 +126,17 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                     # remove the prefix
                     wrd = error.word[len(pre) :]
                     if output_lvl > 1:
-                        print("Trying without prefix: ", error.word, wrd)
+                        print(f"Trying without '{pre}' prefix: {error.word} -> {wrd}")
                     try:
                         if spell_checker.check(wrd):
                             continue
                     except BaseException:
-                        print("Caught an exception for word", error.word, wrd)
+                        print(f"Caught an exception for word {error.word} {wrd}")
 
             # Try splitting camel case words and checking each sub-word
 
             if output_lvl > 1:
-                print("Trying splitting camel case word")
+                print(f"Trying splitting camel case word: {error.word}")
             sub_words = splitCamelCase(error.word)
             if len(sub_words) > 1:
                 ok_flag = True
@@ -154,26 +154,19 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
                     continue
 
             if output_lvl > 1:
-                msg = (
-                    "error: "
-                    + "'"
-                    + error.word
-                    + "', "
-                    + "suggestions: "
-                    + str(spell_checker.suggest())
-                )
+                msg = f"error: '{error.word}', suggestions: {spell_checker.suggest()}"
             else:
                 msg = error.word
             mistakes.append(msg)
 
         if len(mistakes):
             if output_lvl > 0:
-                print("\nLine number", c.line_number())
+                print(f"\nLine number {c.line_number()}")
             if output_lvl > 0:
                 print(c.text())
             for m in mistakes:
                 if output_lvl >= 0:
-                    print("   ", m)
+                    print(f"    {m}")
                 bad_words.append([m, filename, c.line_number()])
 
     bad_words = sorted(bad_words)
@@ -383,15 +376,15 @@ def main():
         suffixes = args.suffix
 
     if output_lvl > 1:
-        print("Prefixes:", prefixes)
-        print("Suffixes:", suffixes)
+        print(f"Prefixes: {prefixes}")
+        print(f"Suffixes: {suffixes}")
 
     #
     # Spell check the files
     #
     for f in file_list:
         if not args.miss:
-            print("\nChecking", f)
+            print(f"\nChecking {f}")
 
         # If f is a directory, recursively check for files in it.
         if os.path.isdir(f):
@@ -407,11 +400,11 @@ def main():
             for x in dir_entries:
                 if exclude_check(x, args.exclude) or skip_check(x, args.skip):
                     if not args.miss:
-                        print("\nExcluding", x)
+                        print(f"\nExcluding {x}")
                     continue
 
                 if not args.miss:
-                    print("\nChecking", x)
+                    print(f"\nChecking {x}")
                 result = spell_check_file(
                     x,
                     spell_checker,
@@ -425,7 +418,7 @@ def main():
             # f is a file
             if exclude_check(f, args.exclude) or skip_check(f, args.skip):
                 if not args.miss:
-                    print("\nExcluding", x)
+                    print(f"\nExcluding {x}")
                 continue
 
             # f is a file, so spell check it
@@ -448,21 +441,21 @@ def main():
 
     for misspelled_word, found_file, line_num in bad_words:
         if misspelled_word != previous_word:
-            print("\n", misspelled_word, ":", sep="")
+            print(f"\n{misspelled_word}:")
 
         if (misspelled_word == previous_word) and args.first:
             sys.stderr.write(".")
             continue
 
         if args.vim:
-            print("    vim +", line_num, " ", found_file, sep="", file=sys.stderr)
+            print(f"    vim +{line_num} {found_file}", file=sys.stderr)
         else:
-            print("    ", found_file, ", ", line_num, sep="", file=sys.stderr)
+            print(f"    {found_file}, {line_num}", file=sys.stderr)
 
         previous_word = misspelled_word
 
     print("")
-    print(len(bad_words), "misspellings found")
+    print(f"{len(bad_words)} misspellings found")
 
     sys.exit(len(bad_words))
 

--- a/codespell.py
+++ b/codespell.py
@@ -124,6 +124,21 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
 
             error_word = error.word
 
+            valid = False
+
+            # Check for contractions
+            for contraction in ["'d", "'s", "'th"]:
+                if error_word.endswith(contraction):
+                    error_word = error_word[: -len(contraction)]
+                    if output_lvl > 1:
+                        print(f"Stripping contraction: {error.word} -> {error_word}")
+                    if spell_checker.check(error_word):
+                        valid = True
+                    break
+
+            if valid:
+                continue
+
             # Check if the bad word starts with a prefix.
             # If so, spell check the word without that prefix.
             #
@@ -152,13 +167,6 @@ def spell_check_file(filename, spell_checker, mime_type="", output_lvl=1, prefix
             sub_words = splitCamelCase(error_word)
             if len(sub_words) > 1 and checkWords(spell_checker, sub_words):
                 continue
-
-            # Check for possessive words
-
-            if error_word.endswith("'s"):
-                wrd = error_word[:-2]
-                if spell_checker.check(wrd):
-                    continue
 
             if output_lvl > 1:
                 msg = f"error: '{error.word}', suggestions: {spell_checker.suggest()}"

--- a/tests/example.h
+++ b/tests/example.h
@@ -18,6 +18,11 @@
 //
 // Additional dictionary test word:
 // TarHeels
+//
+// Contraction test words:
+// With multiple parameters OR'd to compose the flag.
+// With node id's.
+// With the itemIndex'th where itemIndex is a variable name.
 
 #include <stdio.h>
 

--- a/tests/example.h
+++ b/tests/example.h
@@ -12,6 +12,7 @@
 //
 // Prefix and camel case test word:
 // sitkWhiskeyTangoFoxtrot
+// myprefixAttributeName
 //
 // Dictionary test word:
 // BinaryFillholeImageFilter

--- a/tests/test_codespell.py
+++ b/tests/test_codespell.py
@@ -23,6 +23,8 @@ class TestCodespell(unittest.TestCase):
                 "--verbose",
                 "--dict",
                 "tests/dict.txt",
+                "--prefix",
+                "myprefix",
                 "tests/example.h",
             ]
         )
@@ -38,6 +40,8 @@ class TestCodespell(unittest.TestCase):
                 "python",
                 "codespell.py",
                 "--verbose",
+                "--prefix",
+                "myprefix",
                 "--suffix",
                 ".py",
                 "--suffix",


### PR DESCRIPTION
### Summary

* Generalize handling of contractions like "'d", "'s" or "'th"
* Perform camel case splitting after removing the prefix
  * Since a given prefix may not have been added to the dictionary, adds an explicit check to verify that the remaining of the word is valid after stripping the prefix.
* Output readability improvements
* Reduce complexity introducing functions like `spell_check_comment` and `checkWords`
* Miscellaneous optimization

_Note that additional test cases have also been introduced._

### Output

**After:**

```
Additional dictionary: /home/jcfr/Projects/SimpleITKSpellChecking/additional_dictionary.txt
Additional dictionary: tests/dict.txt
Prefixes: ['sitk', 'itk', 'vtk', 'myprefix']
Suffixes: ['.h']

Checking tests/example.h
spell_check_file: tests/example.h, text/x-c++
Line 3:  Mary had a little lamb
Line 4: 
Line 5:  Prefix test words:
Line 6:  sitkBanana
Error: sitkBanana
Trying without 'sitk' prefix: sitkBanana -> Banana
Line 7:  vtkApple
Error: vtkApple
Trying without 'vtk' prefix: vtkApple -> Apple
Line 8:  itkPineapple
Error: itkPineapple
Trying without 'itk' prefix: itkPineapple -> Pineapple
Line 9: 
Line 10:  Camel case test word:
Line 11:  CamelCaseTestWord
[...]
```

**Before:**

```
Prefixes: ['sitk', 'itk', 'vtk']
Suffixes: ['.h']

Checking tests/example.h
spell_check_file: tests/example.h , text/x-c++
Comment:   Mary had a little lamb
<class 'comment_parser.parsers.common.Comment'>
Comment:  
<class 'comment_parser.parsers.common.Comment'>
Comment:   Prefix test words:
<class 'comment_parser.parsers.common.Comment'>
Comment:   sitkBanana
<class 'comment_parser.parsers.common.Comment'>
Error: sitkBanana
Trying without prefix:  sitkBanana Banana
Trying splitting camel case word
Comment:   vtkApple
<class 'comment_parser.parsers.common.Comment'>
Error: vtkApple
Trying without prefix:  vtkApple Apple
Trying splitting camel case word
Comment:   itkPineapple
<class 'comment_parser.parsers.common.Comment'>
Error: itkPineapple
Trying without prefix:  itkPineapple Pineapple
Trying splitting camel case word
Comment:  
<class 'comment_parser.parsers.common.Comment'>
Comment:   Camel case test word:
<class 'comment_parser.parsers.common.Comment'>
Comment:   CamelCaseTestWord
<class 'comment_parser.parsers.common.Comment'>
Error: CamelCaseTestWord
```

