### PR TITLE
BUG: Remove unused test when setting suffixes

### DIFF
--- a/codespell.py
+++ b/codespell.py
@@ -388,10 +388,7 @@ def main():
 
     bad_words = []
 
-    if not args.suffix:
-        suffixes = list(SUFFIX2MIME.keys())
-    else:
-        suffixes = args.suffix
+    suffixes = [*set(args.suffix)]  # remove duplicates
 
     if any([args.brief, output_lvl >= 0]):
         print(f"Prefixes: {prefixes}")


### PR DESCRIPTION
This commit partially reverts 775776e (ENH: Initialize default list of suffixes) removing unused test when setting the suffix variable.

It also ensures there are no duplicated prefixes.