### PR TITLE
ENH: Do not require prefixes to be into additional dict

### DIFF
--- a/codespell.py
+++ b/codespell.py
@@ -146,6 +146,16 @@ def spell_check_comment(
                     if spell_checker.check(wrd):
                         valid = True
                         break
+                    else:
+                        # Try splitting camel case words and checking each sub-words
+                        if output_lvl > 1:
+                            print("Trying splitting camel case word: {wrd}")
+                        sub_words = splitCamelCase(wrd)
+                        if len(sub_words) > 1 and spell_check_words(
+                            spell_checker, sub_words
+                        ):
+                            valid = True
+                            break
                 except BaseException:
                     print(f"Caught an exception for word {error_word} {wrd}")
 

--- a/tests/example.h
+++ b/tests/example.h
@@ -12,6 +12,7 @@
 //
 // Prefix and camel case test word:
 // sitkWhiskeyTangoFoxtrot
+// myprefixAttributeName
 //
 // Dictionary test word:
 // BinaryFillholeImageFilter

--- a/tests/test_codespell.py
+++ b/tests/test_codespell.py
@@ -23,6 +23,8 @@ class TestCodespell(unittest.TestCase):
                 "--verbose",
                 "--dict",
                 "tests/dict.txt",
+                "--prefix",
+                "myprefix",
                 "tests/example.h",
             ]
         )
@@ -38,6 +40,8 @@ class TestCodespell(unittest.TestCase):
                 "python",
                 "codespell.py",
                 "--verbose",
+                "--prefix",
+                "myprefix",
                 "--suffix",
                 ".py",
                 "--suffix",


### PR DESCRIPTION
Do not require prefixes to be specified in the additional dictionary and perform camel case splitting after removing the prefix

Since a given prefix may not have been added to the dictionary, this commit adds an explicit check to verify that the remaining of the word is valid after stripping the prefix.