### PR TITLE
Add GitHub Action to track repository clone traffic

### DIFF
--- a/.github/workflows/track-clones.yml
+++ b/.github/workflows/track-clones.yml
@@ -57,19 +57,23 @@ jobs:
           else:
               data = {"records": []}
 
-          # Merge new daily records, avoiding duplicates by timestamp
-          existing_timestamps = {r["timestamp"] for r in data["records"]}
+          # Merge new daily records, upserting by timestamp (GitHub may adjust recent days)
+          existing_by_timestamp = {r["timestamp"]: r for r in data["records"]}
           added = 0
+          updated = 0
           for clone in api_data.get("clones", []):
-              if clone["timestamp"] not in existing_timestamps:
-                  data["records"].append({
-                      "timestamp": clone["timestamp"],
-                      "count": clone["count"],
-                      "uniques": clone["uniques"],
-                  })
-                  existing_timestamps.add(clone["timestamp"])
+              ts = clone["timestamp"]
+              if ts in existing_by_timestamp:
+                  rec = existing_by_timestamp[ts]
+                  if rec.get("count") != clone["count"] or rec.get("uniques") != clone["uniques"]:
+                      rec["count"] = clone["count"]
+                      rec["uniques"] = clone["uniques"]
+                      updated += 1
+              else:
+                  rec = {"timestamp": ts, "count": clone["count"], "uniques": clone["uniques"]}
+                  data["records"].append(rec)
+                  existing_by_timestamp[ts] = rec
                   added += 1
-
           # Keep records sorted chronologically
           data["records"].sort(key=lambda x: x["timestamp"])
 

--- a/.github/workflows/track-clones.yml
+++ b/.github/workflows/track-clones.yml
@@ -1,0 +1,97 @@
+name: Track Repository Clones
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
+  workflow_dispatch:      # Allow manual triggering
+
+permissions:
+  contents: write
+
+jobs:
+  track-clones:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch and store clone statistics
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 << 'EOF'
+          import json
+          import os
+          import urllib.request
+          import urllib.error
+          from datetime import datetime, timezone
+
+          token = os.environ["GH_TOKEN"]
+          repo = os.environ["REPO"]
+          tracking_file = ".github/clone-traffic.json"
+
+          # Fetch from GitHub Traffic API
+          url = f"https://api.github.com/repos/{repo}/traffic/clones"
+          req = urllib.request.Request(url, headers={
+              "Authorization": f"token {token}",
+              "Accept": "application/vnd.github.v3+json",
+          })
+
+          try:
+              with urllib.request.urlopen(req) as response:
+                  api_data = json.loads(response.read())
+          except urllib.error.HTTPError as e:
+              print(f"HTTP Error {e.code}: {e.reason}")
+              print(e.read().decode())
+              raise SystemExit(1)
+
+          # Load existing tracking data
+          os.makedirs(".github", exist_ok=True)
+          if os.path.exists(tracking_file):
+              with open(tracking_file, "r") as f:
+                  data = json.load(f)
+          else:
+              data = {"records": []}
+
+          # Merge new daily records, avoiding duplicates by timestamp
+          existing_timestamps = {r["timestamp"] for r in data["records"]}
+          added = 0
+          for clone in api_data.get("clones", []):
+              if clone["timestamp"] not in existing_timestamps:
+                  data["records"].append({
+                      "timestamp": clone["timestamp"],
+                      "count": clone["count"],
+                      "uniques": clone["uniques"],
+                  })
+                  existing_timestamps.add(clone["timestamp"])
+                  added += 1
+
+          # Keep records sorted chronologically
+          data["records"].sort(key=lambda x: x["timestamp"])
+
+          # Update summary fields
+          data["total_clones"] = sum(r["count"] for r in data["records"])
+          data["total_unique_cloners"] = sum(r["uniques"] for r in data["records"])
+          data["last_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+          with open(tracking_file, "w") as f:
+              json.dump(data, f, indent=2)
+              f.write("\n")
+
+          print(f"Added {added} new record(s). Total records: {len(data['records'])}")
+          print(f"Cumulative clones: {data['total_clones']}")
+          EOF
+
+      - name: Commit updated statistics
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/clone-traffic.json
+          if git diff --staged --quiet; then
+            echo "No new data to commit."
+          else
+            git commit -m "chore: update clone traffic statistics [skip ci]"
+            git push
+          fi

--- a/.github/workflows/track-clones.yml
+++ b/.github/workflows/track-clones.yml
@@ -75,7 +75,7 @@ jobs:
 
           # Update summary fields
           data["total_clones"] = sum(r["count"] for r in data["records"])
-          data["total_unique_cloners"] = sum(r["uniques"] for r in data["records"])
+          data["total_daily_unique_cloners"] = sum(r["uniques"] for r in data["records"])
           data["last_updated"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
           with open(tracking_file, "w") as f:

--- a/.github/workflows/track-clones.yml
+++ b/.github/workflows/track-clones.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: track-clones-${{ github.ref }}
 jobs:
   track-clones:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a daily scheduled workflow (`.github/workflows/track-clones.yml`) that:

- Calls the GitHub Traffic API to fetch clone statistics
- Accumulates daily records in `.github/clone-traffic.json`, deduplicating by timestamp
- Commits updated data back to the repo with `[skip ci]`

**Setup required:** Add a PAT with repo traffic read access as a repository secret named `TRAFFIC_TOKEN`.